### PR TITLE
Fixing Malvid travis link to get build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Malvid
 
-[![Travis Build Status](https://travis-ci.org/comwrap/Malvid.svg?branch=master)](https://travis-ci.org/comwrap/Malvid) [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/6fxwnrdhoh7xw9n1?svg=true)](https://ci.appveyor.com/project/electerious/malvid) [![Coverage Status](https://coveralls.io/repos/github/comwrap/Malvid/badge.svg?branch=master)](https://coveralls.io/github/comwrap/Malvid?branch=master)  [![Dependencies](https://david-dm.org/comwrap/Malvid.svg)](https://david-dm.org/comwrap/Malvid#info=dependencies) [![Greenkeeper badge](https://badges.greenkeeper.io/Malvid/Malvid.svg)](https://greenkeeper.io/)
+[![Travis Build Status](https://travis-ci.org/Malvid/Malvid.svg?branch=master)](https://travis-ci.org/Malvid/Malvid) [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/6fxwnrdhoh7xw9n1?svg=true)](https://ci.appveyor.com/project/electerious/malvid) [![Coverage Status](https://coveralls.io/repos/github/comwrap/Malvid/badge.svg?branch=master)](https://coveralls.io/github/comwrap/Malvid?branch=master)  [![Dependencies](https://david-dm.org/comwrap/Malvid.svg)](https://david-dm.org/comwrap/Malvid#info=dependencies) [![Greenkeeper badge](https://badges.greenkeeper.io/Malvid/Malvid.svg)](https://greenkeeper.io/)
 
 UI to help you build and document web components.
 


### PR DESCRIPTION
Just a suggestion on fixing the link to the build to see the current status.