### PR TITLE
ci: test latest Node.js (11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 'stable'
+  - 'node'
   - '10'
   - '8'
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - 'stable'
   - '10'
   - '8'
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - nodejs_version: "stable"
+    - nodejs_version: "11"
     - nodejs_version: "10"
     - nodejs_version: "8"
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+    - nodejs_version: "stable"
     - nodejs_version: "10"
     - nodejs_version: "8"
 install:


### PR DESCRIPTION
Node.js 11 should be also tested to prevent any breaking builds / installs on the latest release line.