### PR TITLE
chore: downgrade glamor to v2, v3 is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "filename-regex": "^2.0.1",
     "find-up": "^3.0.0",
     "fs-extra": "^7.0.0",
-    "glamor": "^3.0.0-2",
+    "glamor": "^2.20.40",
     "highlight.js": "^9.13.1",
     "history": "^4.7.2",
     "is-hotkey": "^0.1.3",


### PR DESCRIPTION
glamor v3 is deprecated

> npm WARN deprecated glamor@3.0.0-3: abandoned, please use v2 instead